### PR TITLE
Upgrade and extend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ RUN apk --no-cache --upgrade add ca-certificates curl groff less python py-pip &
 COPY handler.py /usr/local/bin/handler.py
 COPY start /usr/local/bin/start
 
+ENV MAX_NODES=-1
+
 ENTRYPOINT ["/usr/local/bin/start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,14 @@
-FROM alpine
+FROM unifio/consul:0.6.4
+MAINTAINER Unif.io, Inc. <support@unif.io>
 
-RUN apk -Uuv add groff less python py-pip && \
-    pip install awscli && \
-    pip install boto && \
+RUN apk --no-cache --upgrade add ca-certificates curl groff less python py-pip && \
+    pip install awscli boto && \
+    curl -Ls "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk" > /tmp/glibc-2.23-r3.apk && \
+    apk --allow-untrusted add /tmp/glibc-2.23-r3.apk && \
     apk --purge -v del py-pip && \
-    rm /var/cache/apk/*
+    rm -rf /tmp/glibc-2.21-r2.apk
 
-ENV CONSUL_VERSION 0.5.2
-RUN apk --update add curl ca-certificates && \
-    curl -Ls https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk > /tmp/glibc-2.21-r2.apk && \
-    apk add --allow-untrusted /tmp/glibc-2.21-r2.apk && \
-    rm -rf /tmp/glibc-2.21-r2.apk /var/cache/apk/*
+COPY handler.py /usr/local/bin/handler.py
+COPY start /usr/local/bin/start
 
-ADD https://dl.bintray.com/mitchellh/consul/${CONSUL_VERSION}_linux_amd64.zip /tmp/consul.zip
-RUN unzip /tmp/consul.zip \
-    && chmod +x consul \
-    && rm /tmp/consul.zip
-
-ADD handler.py /
-ADD start /
-
-ENTRYPOINT ["/start"]
-CMD []
+ENTRYPOINT ["/usr/local/bin/start"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ELB Consul
 
+[![CircleCI](https://circleci.com/gh/unifio/docker-elb-consul.svg?style=svg)](https://circleci.com/gh/unifio/docker-elb-consul)
+
 This Docker image allows you to (de)register EC2 instances belonging to a specific Consul service with an Amazon Elastic Load Balancer (ELB).
 
 ## Usage
@@ -9,9 +11,10 @@ The `elb-consul` image takes all of its configuration from environment variables
 * `AWS_ACCESS_KEY_ID` ... Your AWS [access key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html)
 * `AWS_SECRET_ACCESS_KEY` ... Your AWS [secret key](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/AWSCredentials.html)
 * `AWS_REGION` ... The AWS region that your load balancer is located in
-* `ELB_NAME` ... The exact name of your load balancer
 * `CONSUL_SERVER` ... The IP:PORT to connect to the Consul server (eg: 172.1.6.1.2:8500)
 * `CONSUL_SERVICE` ... The exact name of the Consul service you want to monitor
+* `ELB_NAME` ... The exact name of your load balancer
+* `MAX_NODES` ... Maximum number of healthy instances to registry with your load balancer. Defaults to `-1` for unlimited instances.
 
 You could run only one instance of `elb-consul` per `ELB_NAME` / `CONSUL_SERVICE` pair but for high availability purpose, it is recommanded to run two of them.
 Internally the Docker image uses a Consul Lock to make sure that only one `elb-consul` will be active at anytime.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,27 @@
+machine:
+  environment:
+    CONSUL_VERSION: 0.6.4
+  services:
+    - docker
+
+dependencies:
+  cache_directories:
+    - "~/docker"
+  override:
+    - docker info
+    - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
+    - docker build -t unifio/elb-consul .
+    - mkdir -p ~/docker
+    - docker save unifio/elb-consul > ~/docker/image.tar
+
+test:
+  override:
+    - "docker run --entrypoint /bin/sh unifio/elb-consul -c \"/bin/dumb-init /bin/gosu consul /bin/consul version\""
+
+deployment:
+  hub:
+    branch: master
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag -f `docker images | grep -E 'unifio/elb-consul' | awk '{print $3}'` unifio/elb-consul:${CONSUL_VERSION}
+      - docker push unifio/elb-consul

--- a/start
+++ b/start
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /consul lock -http-addr=$CONSUL_SERVER lock/elb-consul/$AWS_REGION/$ELB_NAME /consul watch -http-addr=$CONSUL_SERVER -type=service -service=$CONSUL_SERVICE ./handler.py
+exec /bin/dumb-init /bin/gosu consul /bin/consul lock -http-addr=$CONSUL_SERVER -n=1 lock/elb-consul/$AWS_REGION/$ELB_NAME /bin/consul watch -http-addr=$CONSUL_SERVER -type=service -service=$CONSUL_SERVICE /usr/local/bin/handler.py


### PR DESCRIPTION
Updated image to leverage Consul 0.6.4 as well as other HashiCorp best practices for containerizing their applications.

Extended the script to allow setting a cap to the number of healthy nodes that are registered with the ELB.